### PR TITLE
Move markdown-unlit to build-tools

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -48,7 +48,6 @@ import Data.Text
 import qualified Data.Yaml as Yaml
 import GHC.Generics (Generic)
 import Test.Hspec
-import Text.Markdown.Unlit ()
 
 ```
 -->

--- a/interpolated-data.cabal
+++ b/interpolated-data.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -67,13 +67,14 @@ test-suite readme
       RecordWildCards
       TypeApplications
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -pgmL markdown-unlit
+  build-tool-depends:
+      markdown-unlit:markdown-unlit
   build-depends:
       aeson
     , base <5
     , containers
     , hspec
     , interpolated-data
-    , markdown-unlit
     , text
     , yaml
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -64,6 +64,7 @@ tests:
       - containers
       - hspec
       - interpolated-data
-      - markdown-unlit
       - text
       - yaml
+    build-tools:
+      - markdown-unlit


### PR DESCRIPTION
## Summary

This PR moves `markdown-unlit` from `dependencies` to `build-tools` in the package.yaml test configuration and removes the corresponding empty import from README.lhs.

## Why this change?

When `markdown-unlit` is listed in `dependencies`, we need to import it in the Haskell code to avoid unused-package warnings from GHC. However, since `markdown-unlit` is only used as a preprocessor (via `-pgmL markdown-unlit`), we don't actually need to import anything from it in our code.

By moving it to `build-tools` instead, we:
- Avoid unused-package warnings without needing empty imports
- Make the dependency relationship clearer (it's a build tool, not a runtime dependency)
- Follow Stack/Cabal best practices for preprocessor dependencies

## Changes

- Moved `markdown-unlit` from `dependencies` to `build-tools` in package.yaml
- Removed `import Text.Markdown.Unlit ()` from README.lhs
- Regenerated any files via `stack build --fast --test --no-run-tests`

🤖 Generated with Claude Code